### PR TITLE
Add a systemd service that triggers ODCS to clean up older composes

### DIFF
--- a/files/odcs-celery-cleanup.service
+++ b/files/odcs-celery-cleanup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=ODCS Celery Cleanup
+After=network.target
+
+[Service]
+Type=Simple
+User=odcs-server
+Group=odcs-server
+ExecStart=/bin/sh -c '/usr/bin/celery-3 -A odcs.server.celery_tasks beat --loglevel=debug'
+
+[Install]
+WantedBy=multi-user.target

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -247,6 +247,17 @@
   tags:
   - odcs
 
+- name: Install the ODCS Cleanup systemd service
+  copy:
+    src: "odcs-celery-cleanup.service"
+    dest: "/etc/systemd/system/odcs-celery-cleanup.service"
+    owner: root
+    group: root
+    mode: 0644
+  tags:
+    - odcs
+
+
 - name: start ODCS frontend
   systemd:
     name: httpd
@@ -254,6 +265,13 @@
   tags:
   - odcs
 
+- name: start the ODCS Cleanup service
+  systemd:
+    name: "odcs-celery-cleanup"
+    state: started
+    enabled: true
+  tags:
+    - odcs
 
 - include_role:
     name: vsftpd


### PR DESCRIPTION
ODCS has an internal mechanism based on the TTL that we specify for each compose when we submit it to the api. This systemd service starts a celery task that produces a regular "heartbeat" message on the private message bus. ODCS listens for the heartbeat and knows which composes to clean up based on those that have passed their TTL.

Signed-off-by: Brian Stinson <brian@bstinson.com>